### PR TITLE
Integrate Paddle API to charge users after subscription plan

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+PADDLE_VENDOR_ID=your_paddle_vendor_id
+PADDLE_API_KEY=your_paddle_api_key

--- a/public/upgrade.html
+++ b/public/upgrade.html
@@ -34,9 +34,26 @@
     </ul>
   </div>
   <script>
-    function upgradeSubscription(plan) {
-      // Implement the logic to upgrade the subscription plan
-      alert(`Upgrading to ${plan} plan`);
+    async function upgradeSubscription(plan) {
+      try {
+        const response = await fetch('/subscription/upgrade', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ plan }),
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to upgrade subscription');
+        }
+
+        const data = await response.json();
+        alert(`Subscription upgraded to ${plan} plan successfully`);
+      } catch (error) {
+        console.error('Error upgrading subscription:', error);
+        alert('Failed to upgrade subscription');
+      }
     }
   </script>
 </body>

--- a/src/logic/paddle.js
+++ b/src/logic/paddle.js
@@ -1,0 +1,61 @@
+const axios = require('axios');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const PADDLE_VENDOR_ID = process.env.PADDLE_VENDOR_ID;
+const PADDLE_API_KEY = process.env.PADDLE_API_KEY;
+const PADDLE_API_URL = 'https://vendors.paddle.com/api/2.0';
+
+const createSubscription = async (planId, userEmail) => {
+  try {
+    const response = await axios.post(`${PADDLE_API_URL}/subscription/users/create`, {
+      vendor_id: PADDLE_VENDOR_ID,
+      vendor_auth_code: PADDLE_API_KEY,
+      plan_id: planId,
+      user_email: userEmail,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error creating subscription:', error);
+    throw new Error('Failed to create subscription');
+  }
+};
+
+const cancelSubscription = async (subscriptionId) => {
+  try {
+    const response = await axios.post(`${PADDLE_API_URL}/subscription/users_cancel`, {
+      vendor_id: PADDLE_VENDOR_ID,
+      vendor_auth_code: PADDLE_API_KEY,
+      subscription_id: subscriptionId,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error canceling subscription:', error);
+    throw new Error('Failed to cancel subscription');
+  }
+};
+
+const updateSubscription = async (subscriptionId, planId) => {
+  try {
+    const response = await axios.post(`${PADDLE_API_URL}/subscription/users/update`, {
+      vendor_id: PADDLE_VENDOR_ID,
+      vendor_auth_code: PADDLE_API_KEY,
+      subscription_id: subscriptionId,
+      plan_id: planId,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error updating subscription:', error);
+    throw new Error('Failed to update subscription');
+  }
+};
+
+module.exports = {
+  createSubscription,
+  cancelSubscription,
+  updateSubscription,
+};

--- a/src/routes/subscription.route.js
+++ b/src/routes/subscription.route.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const Subscription = require('../models/subscription');
 const User = require('../models/user');
 const { sendEmailNotification } = require('../logic/emailNotifications');
+const { createSubscription, cancelSubscription, updateSubscription } = require('../logic/paddle');
 
 // Route to get all subscription plans
 router.get('/plans', async (req, res) => {
@@ -26,6 +27,11 @@ router.post('/upgrade', async (req, res) => {
     const plan = await Subscription.findById(planId);
     if (!plan) {
       return res.status(404).json({ error: 'Subscription plan not found' });
+    }
+
+    const paddleResponse = await createSubscription(planId, user.email);
+    if (!paddleResponse.success) {
+      return res.status(500).json({ error: 'Failed to create subscription with Paddle' });
     }
 
     user.subscription = planId;
@@ -52,6 +58,11 @@ router.post('/downgrade', async (req, res) => {
     const plan = await Subscription.findById(planId);
     if (!plan) {
       return res.status(404).json({ error: 'Subscription plan not found' });
+    }
+
+    const paddleResponse = await updateSubscription(user.subscription, planId);
+    if (!paddleResponse.success) {
+      return res.status(500).json({ error: 'Failed to update subscription with Paddle' });
     }
 
     user.subscription = planId;


### PR DESCRIPTION
Integrate Paddle API to charge users after a subscription plan.

* **Add Paddle API integration**: Create `src/logic/paddle.js` to handle Paddle API interactions, including functions to create, cancel, and update subscriptions.
* **Update subscription routes**: Modify `src/routes/subscription.route.js` to import Paddle API functions and call them for creating and managing subscriptions.
* **Modify upgrade functionality**: Update `public/upgrade.html` to call the updated subscription routes for upgrading subscriptions.
* **Add environment variables**: Include Paddle API credentials in the `.env` file.

